### PR TITLE
Require C++ 17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
                 "leveldb-mcpe/include",
             ],
             language="c++",
+            extra_compile_args=["-std=c++17"],
             extra_objects=extra_objects,
             libraries=libraries,
             define_macros=define_macros,


### PR DESCRIPTION
C++ 17 is required for the locking behaviour.
This is apparently the default for the windows testers but not unix.