### PR TITLE
Fix builds

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,19 +15,24 @@ jobs:
         cfg:
           - { os: windows-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x86, python-version: "3.8" }
-          - { os: macos-latest, architecture: x64, python-version: "3.8" }
+          - { os: macos-13, architecture: x64, python-version: "3.8" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.8" }
           - { os: windows-latest, architecture: x64, python-version: "3.9" }
           - { os: windows-latest, architecture: x86, python-version: "3.9" }
-          - { os: macos-latest, architecture: x64, python-version: "3.9" }
+          - { os: macos-13, architecture: x64, python-version: "3.9" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.9" }
           - { os: windows-latest, architecture: x64, python-version: "3.10" }
           - { os: windows-latest, architecture: x86, python-version: "3.10" }
-          - { os: macos-latest, architecture: x64, python-version: "3.10" }
+          - { os: macos-13, architecture: x64, python-version: "3.10" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.10" }
           - { os: windows-latest, architecture: x64, python-version: "3.11" }
           - { os: windows-latest, architecture: x86, python-version: "3.11" }
-          - { os: macos-latest, architecture: x64, python-version: "3.11" }
+          - { os: macos-13, architecture: x64, python-version: "3.11" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.11" }
           - { os: windows-latest, architecture: x64, python-version: "3.12" }
           - { os: windows-latest, architecture: x86, python-version: "3.12" }
-          - { os: macos-latest, architecture: x64, python-version: "3.12" }
+          - { os: macos-13, architecture: x64, python-version: "3.12" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.12" }
 
     runs-on: ${{ matrix.cfg.os }}
 

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy:
     strategy:
+      fail-fast: false
       matrix:
         cfg:
           - { os: windows-latest, architecture: x64, python-version: "3.7" }

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - { os: windows-latest, architecture: x64, python-version: "3.7" }
-          - { os: windows-latest, architecture: x86, python-version: "3.7" }
-          - { os: macos-latest, architecture: x64, python-version: "3.7" }
           - { os: windows-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x86, python-version: "3.8" }
           - { os: macos-latest, architecture: x64, python-version: "3.8" }

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: ubuntu-latest, architecture: x64, python-version: "3.7" }
           - { os: windows-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x86, python-version: "3.8" }
           - { os: macos-13, architecture: x64, python-version: "3.8" }

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -18,9 +18,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: windows-latest, architecture: x64, python-version: "3.7" }
-          - { os: windows-latest, architecture: x86, python-version: "3.7" }
-          - { os: macos-latest, architecture: x64, python-version: "3.7" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.7" }
           - { os: windows-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x86, python-version: "3.8" }

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -21,23 +21,28 @@ jobs:
           - { os: ubuntu-latest, architecture: x64, python-version: "3.7" }
           - { os: windows-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x86, python-version: "3.8" }
-          - { os: macos-latest, architecture: x64, python-version: "3.8" }
+          - { os: macos-13, architecture: x64, python-version: "3.8" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.8" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.8" }
           - { os: windows-latest, architecture: x64, python-version: "3.9" }
           - { os: windows-latest, architecture: x86, python-version: "3.9" }
-          - { os: macos-latest, architecture: x64, python-version: "3.9" }
+          - { os: macos-13, architecture: x64, python-version: "3.9" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.9" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.9" }
           - { os: windows-latest, architecture: x64, python-version: "3.10" }
           - { os: windows-latest, architecture: x86, python-version: "3.10" }
-          - { os: macos-latest, architecture: x64, python-version: "3.10" }
+          - { os: macos-13, architecture: x64, python-version: "3.10" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.10" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.10" }
           - { os: windows-latest, architecture: x64, python-version: "3.11" }
           - { os: windows-latest, architecture: x86, python-version: "3.11" }
-          - { os: macos-latest, architecture: x64, python-version: "3.11" }
+          - { os: macos-13, architecture: x64, python-version: "3.11" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.11" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.11" }
           - { os: windows-latest, architecture: x64, python-version: "3.12" }
           - { os: windows-latest, architecture: x86, python-version: "3.12" }
-          - { os: macos-latest, architecture: x64, python-version: "3.12" }
+          - { os: macos-13, architecture: x64, python-version: "3.12" }
+          - { os: macos-latest, architecture: arm64, python-version: "3.12" }
           - { os: ubuntu-latest, architecture: x64, python-version: "3.12" }
 
     runs-on: ${{ matrix.cfg.os }}


### PR DESCRIPTION
Disable fast failing so that if one build fails for some reason the rest will complete.
Disable Python 3.7 because it has reached end of life.
Fix macos architecture issues.