### PR TITLE
Improve build tooling

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -13,28 +13,63 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - { os: ubuntu-latest, architecture: x64, python-version: "3.11" }
+          - { python-version: "3.11", os: windows-latest, architecture: x64 }
+          - { python-version: "3.11", os: macos-13, architecture: x64 }
+          - { python-version: "3.11", os: macos-latest, architecture: arm64 }
+          - { python-version: "3.12", os: windows-latest, architecture: x64 }
+          - { python-version: "3.12", os: macos-13, architecture: x64 }
+          - { python-version: "3.12", os: macos-latest, architecture: arm64 }
+          - { python-version: "3.13", os: windows-latest, architecture: x64 }
+          - { python-version: "3.13", os: macos-13, architecture: x64 }
+          - { python-version: "3.13", os: macos-latest, architecture: arm64 }
 
     runs-on: ${{ matrix.cfg.os }}
+    defaults:
+      run:
+        shell: bash
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+    - name: Clone Amulet-LevelDB
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.cfg.python-version }} ${{ matrix.cfg.architecture }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.cfg.python-version }}
         architecture: ${{ matrix.cfg.architecture }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools build twine
+        pip install build twine
 
-    - name: Build and publish
+    - name: Clone Amulet-Compiler-Version
+      uses: actions/checkout@v4
+      with:
+        repository: 'Amulet-Team/Amulet-Compiler-Version'
+        ref: '1.0'
+        path: 'lib/Amulet-Compiler-Version'
+
+    - name: Build Amulet-Compiler-Version
+      env:
+        BUILD_SPECIALISED: 1
+      run: |
+        python -m build lib/Amulet-Compiler-Version
+
+    - name: Publish Amulet-Compiler-Version
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
+      run: |
+        twine upload lib/Amulet-Compiler-Version/dist/* --skip-existing
+
+    - name: Build Amulet-LevelDB
+      run: |
+        python -m build -C=AMULET_FREEZE_COMPILER=1 .
+
+    - name: Publish Amulet-LevelDB
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_LEVELDB_PYPI_PASSWORD }}
       run: |
-        python -m build --sdist
         twine upload dist/* --skip-existing

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -18,32 +18,38 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: windows-latest, architecture: x64, python-version: "3.11" }
-          - { os: windows-latest, architecture: x86, python-version: "3.11" }
-          - { os: macos-13, architecture: x64, python-version: "3.11" }
-          - { os: macos-latest, architecture: arm64, python-version: "3.11" }
-          - { os: ubuntu-latest, architecture: x64, python-version: "3.11" }
-          - { os: windows-latest, architecture: x64, python-version: "3.12" }
-          - { os: windows-latest, architecture: x86, python-version: "3.12" }
-          - { os: macos-13, architecture: x64, python-version: "3.12" }
-          - { os: macos-latest, architecture: arm64, python-version: "3.12" }
-          - { os: ubuntu-latest, architecture: x64, python-version: "3.12" }
+          - { python-version: "3.11", os: windows-latest, architecture: x64 }
+          - { python-version: "3.11", os: macos-13, architecture: x64 }
+          - { python-version: "3.11", os: macos-latest, architecture: arm64 }
+          - { python-version: "3.11", os: ubuntu-latest, architecture: x64 }
+          - { python-version: "3.12", os: windows-latest, architecture: x64 }
+          - { python-version: "3.12", os: macos-13, architecture: x64 }
+          - { python-version: "3.12", os: macos-latest, architecture: arm64 }
+          - { python-version: "3.12", os: ubuntu-latest, architecture: x64 }
+          - { python-version: "3.13", os: windows-latest, architecture: x64 }
+          - { python-version: "3.13", os: macos-13, architecture: x64 }
+          - { python-version: "3.13", os: macos-latest, architecture: arm64 }
+          - { python-version: "3.13", os: ubuntu-latest, architecture: x64 }
 
     runs-on: ${{ matrix.cfg.os }}
+    defaults:
+      run:
+        shell: bash
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.cfg.python-version }} ${{ matrix.cfg.architecture }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.cfg.python-version }}
         architecture: ${{ matrix.cfg.architecture }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        pip install -vvvv .
+        pip install -vv .
+
     - name: Test with unittest
       run: python -m unittest discover -v -s tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include build_requires.py
+
 recursive-include src/leveldb *.hpp *.cpp *Config.cmake
 
 include CMakeLists.txt

--- a/build_requires.py
+++ b/build_requires.py
@@ -1,0 +1,21 @@
+from typing import Union, Mapping
+
+from setuptools import build_meta
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_wheel(
+    config_settings: Union[Mapping[str, Union[str, list[str], None]], None] = None,
+) -> list[str]:
+    requirements = []
+    requirements.extend(build_meta.get_requires_for_build_wheel(config_settings))
+    requirements.append("wheel")
+    requirements.append("pybind11[global]==2.13.6")
+    requirements.append(
+        "Amulet-pybind11-extensions@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@d79a41e0cb26c965c34f2b52c85496798e82121f"
+    )
+    if config_settings and config_settings.get("AMULET_FREEZE_COMPILER"):
+        requirements.append(
+            "amulet-compiler-version@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
+        )
+    return requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,10 @@
 [build-system]
 requires = [
-    "setuptools >= 42",
-    "wheel",
-    "pybind11[global] == 2.13.6",
-    "Amulet-pybind11-extensions @ git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@d79a41e0cb26c965c34f2b52c85496798e82121f",
-    "versioneer"
+    "setuptools>=42",
+    "versioneer",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "build_requires"
+backend-path = [""]
 
 [project]
 name = "amulet-leveldb"
@@ -14,14 +12,11 @@ authors = [
     {name = "James Clare"},
 ]
 description = "A pybind11 wrapper for Mojang's custom LevelDB."
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "dependencies"]
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-]
-dependencies = [
-    "amulet-compiler-target == 1.0"
 ]
 
 [project.optional-dependencies]
@@ -31,14 +26,17 @@ docs = [
     "sphinx_rtd_theme>=0.3.1",
 ]
 dev = [
+    "setuptools>=42",
+    "wheel",
+    "pybind11[global]==2.13.6",
+    "Amulet-pybind11-extensions", #@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@d79a41e0cb26c965c34f2b52c85496798e82121f",
+    "versioneer",
     "black>=22.3",
     "pre_commit>=1.11.1",
     "isort",
     "autoflake",
     "mypy",
     "types-pyinstaller",
-    "wheel",
-    "versioneer",
     "pybind11_stubgen" # @ git+https://github.com/Amulet-Team/pybind11-stubgen.git@c3a6ef67ec23d5a39e8cdc73b2c3cd8c1794d6f2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,30 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-import pybind11
-import shutil
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
 
 import versioneer
-import pybind11_extensions
 
+dependencies = [
+    "amulet-compiler-target==1.0",
+]
+setup_args = {}
 
-# https://github.com/pybind/cmake_example/blob/master/setup.py
-class CMakeExtension(Extension):
-    def __init__(self, name: str, sourcedir: str = "") -> None:
-        super().__init__(name, sources=[])
-        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+try:
+    import amulet_compiler_version
+except ImportError:
+    dependencies.append("amulet-compiler-version==1.3.0")
+else:
+    dependencies.append(
+        f"amulet-compiler-version=={amulet_compiler_version.__version__}"
+    )
+    setup_args["options"] = {
+        "bdist_wheel": {
+            "build_number": f"1.{amulet_compiler_version.compiler_id}.{amulet_compiler_version.compiler_version}"
+        }
+    }
 
 
 cmdclass: dict[str, type[Command]] = versioneer.get_cmdclass()
@@ -24,6 +33,9 @@ cmdclass: dict[str, type[Command]] = versioneer.get_cmdclass()
 
 class CMakeBuild(cmdclass.get("build_ext", build_ext)):
     def build_extension(self, ext):
+        import pybind11
+        import pybind11_extensions
+
         ext_fullpath = Path.cwd() / self.get_ext_fullpath("")
         src_dir = ext_fullpath.parent.resolve()
 
@@ -68,5 +80,7 @@ cmdclass["build_ext"] = CMakeBuild
 setup(
     version=versioneer.get_version(),
     cmdclass=cmdclass,
-    ext_modules=[CMakeExtension("leveldb._leveldb")],
+    ext_modules=[Extension("leveldb._leveldb", [])],
+    install_requires=dependencies,
+    **setup_args,
 )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -139,7 +139,7 @@ class LevelDBTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 del db[b"key"]
             with self.assertRaises(RuntimeError):
-                list(db.iterate(b"\x00", b"\xFF"))
+                list(db.iterate(b"\x00", b"\xff"))
             with self.assertRaises(RuntimeError):
                 list(db.keys())
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Added amulet-compiler-version dependency. This ensures that pre-compiled packages are compatible with each other.
When the sdist version is compiled on the user's computer it will target the unspecialised version (1.3.0) so that it does not consider pre-compiled versions that used a different compiler.
Added a build tag for pre-compiled versions including the compiler id and version to differentiate the same version compiled on different compilers.