### PR TITLE
Add AMULET_FREEZE_COMPILER environment variable

### DIFF
--- a/build_requires.py
+++ b/build_requires.py
@@ -1,4 +1,5 @@
 from typing import Union, Mapping
+import os
 
 from setuptools import build_meta
 from setuptools.build_meta import *
@@ -14,7 +15,9 @@ def get_requires_for_build_wheel(
     requirements.append(
         "Amulet-pybind11-extensions@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@d79a41e0cb26c965c34f2b52c85496798e82121f"
     )
-    if config_settings and config_settings.get("AMULET_FREEZE_COMPILER"):
+    if (
+        config_settings and config_settings.get("AMULET_FREEZE_COMPILER")
+    ) or os.environ.get("AMULET_FREEZE_COMPILER", None):
         requirements.append(
             "amulet-compiler-version@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
         )


### PR DESCRIPTION
Allow AMULET_FREEZE_COMPILER to be configured via an environment variable.
Pip cannot set config settings but can set environment variables